### PR TITLE
Improve algorithm and add benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ keywords = ["integer", "square", "root", "isqrt", "sqrt"]
 categories = ["algorithms", "no-std"]
 license = "Apache-2.0/MIT"
 
+[dependencies]
+num-traits = "0.2"

--- a/benches/sqrt.rs
+++ b/benches/sqrt.rs
@@ -1,0 +1,73 @@
+#![feature(test)]
+
+extern crate test;
+use test::{black_box, Bencher};
+
+extern crate integer_sqrt;
+use integer_sqrt::IntegerSquareRoot;
+
+// Use f64::sqrt to compute the integer sqrt
+fn isqrt_via_f64(n: u64) -> u64 {
+    let cand = (n as f64).sqrt() as u64;
+    // Rounding can cause off-by-one errors
+    if let Some(prod) = cand.checked_mul(cand) {
+        if prod <= n {
+            return cand;
+        }
+    }
+    cand - 1
+}
+
+#[bench]
+fn isqrt_small(b: &mut Bencher) {
+    let small = 63u64;
+    b.iter(|| {
+        let n = black_box(small);
+        assert_eq!(n.integer_sqrt_checked(), Some(7));
+    })
+}
+
+#[bench]
+fn isqrt_med(b: &mut Bencher) {
+    let med = 10_000_000_000u64; // 10^10
+    b.iter(|| {
+        let n = black_box(med);
+        assert_eq!(n.integer_sqrt_checked(), Some(100_000)); // 10^5
+    })
+}
+
+#[bench]
+fn isqrt_large(b: &mut Bencher) {
+    let large = u64::MAX;
+    b.iter(|| {
+        let n = black_box(large);
+        assert_eq!(n.integer_sqrt_checked(), Some((1u64 << 32) - 1));
+    })
+}
+
+#[bench]
+fn isqrt_f64_small(b: &mut Bencher) {
+    let small = 63u64;
+    b.iter(|| {
+        let n = black_box(small);
+        assert_eq!(isqrt_via_f64(n), 7);
+    })
+}
+
+#[bench]
+fn isqrt_f64_med(b: &mut Bencher) {
+    let med = 10_000_000_000u64; // 10^10
+    b.iter(|| {
+        let n = black_box(med);
+        assert_eq!(isqrt_via_f64(n), 100_000); // 10^5
+    })
+}
+
+#[bench]
+fn isqrt_f64_large(b: &mut Bencher) {
+    let large = u64::MAX;
+    b.iter(|| {
+        let n = black_box(large);
+        assert_eq!(isqrt_via_f64(n), (1u64 << 32) - 1);
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,17 +46,18 @@ pub trait IntegerSquareRoot {
 
 #[inline(always)]
 fn integer_sqrt_impl<T: num_traits::PrimInt>(mut n: T) -> Option<T> {
-    // Hopefully this will be stripped for unsigned numbers (impossible condition)
-    if n < T::zero() {
-        return None;
+    use core::cmp::Ordering;
+    match n.cmp(&T::zero()) {
+        // Hopefully this will be stripped for unsigned numbers (impossible condition)
+        Ordering::Less => return None,
+        Ordering::Equal => return Some(T::zero()),
+        _ => {}
     }
 
     // Compute bit, the largest power of 4 <= n
-    use core::mem::size_of;
-    let mut bit = T::one().unsigned_shl(size_of::<T>() as u32 * 8 - 2);
-    while bit > n {
-        bit = bit.unsigned_shr(2);
-    }
+    let max_shift: u32 = T::zero().leading_zeros() - 1;
+    let shift: u32 = (max_shift - n.leading_zeros()) & !1;
+    let mut bit = T::one().unsigned_shl(shift);
 
     // Algorithm based on the implementation in:
     // https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_(base_2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,8 @@ pub trait IntegerSquareRoot {
         Self: Sized;
 }
 
-// This could be more optimized
 macro_rules! impl_isqrt {
-    () => ();
-    ($t:ty) => {impl_isqrt!($t,);};
-    ($t:ty, $($e:tt)*) => {
+    ($($t:ty)*) => { $(
         impl IntegerSquareRoot for $t {
             #[allow(unused_comparisons)]
             fn integer_sqrt_checked(&self) -> Option<Self> {
@@ -86,12 +83,10 @@ macro_rules! impl_isqrt {
                 Some(result)
             }
         }
-
-        impl_isqrt!($($e)*);
-    };
+    )* };
 }
 
-impl_isqrt!(usize, u128, u64, u32, u16, u8, isize, i128, i64, i32, i16, i8);
+impl_isqrt!(usize u128 u64 u32 u16 u8 isize i128 i64 i32 i16 i8);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Fixes #4 by implementing [an improved version of the digit-based algorithm](https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_(base_2)).

The new algorithm only uses addtions, checked subtractions, and shifts. This makes it about twice as fast.

Results (in nanoseconds, on my x86_64 desktop, lower is better):
| Input | Existing Algo | New Algo | New Algo w/ `leading_zeros` | `f64::sqrt()` |
| --- | --- | --- | --- | --- |
| `u64::MAX` | 66 | **30** | 32 | 5 |
| `10^10` | 32 | 18 | **16** | 5 |
| `63` | 4 | 10 | **3** | 5 |

The implementation now uses the `num_traits::PrimInt` trait so that
 - the implementation can be an normal generic function (instead of a macro)
 - `unsigned_shr` doesn't need to be implemented in this crate

The macro is simplified in this PR, and is completely removed in #11. See individual commits for more information.